### PR TITLE
Make it possible to compile from sources against numpy on macOS aarch64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
   "setuptools", "wheel", "scikit-build", "cmake", "pip",
   "numpy==1.13.3; python_version=='3.6' and platform_machine != 'aarch64'",
   "numpy==1.19.3; python_version>='3.6' and sys_platform == 'linux' and platform_machine == 'aarch64'",
+  "numpy==1.20.1; python_version>='3.6' and sys_platform == 'darwin' and platform_machine == 'aarch64'",
   "numpy==1.14.5; python_version=='3.7' and platform_machine != 'aarch64'",
   "numpy==1.17.3; python_version=='3.8' and platform_machine != 'aarch64'",
   "numpy==1.19.3; python_version>='3.9' and platform_machine != 'aarch64'"

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,13 @@ def main():
     if sys.version_info[:2] >= (3, 9):
         minimum_supported_numpy = "1.19.3"
 
-    # arm64 is a special case
-    if sys.version_info[:2] >= (3, 6) and platform.machine() == "aarch64":
+    # linux arm64 is a special case
+    if sys.platform.startswith("linux") and sys.version_info[:2] >= (3, 6) and platform.machine() == "aarch64":
         minimum_supported_numpy = "1.19.3"
+
+    # macos arm64 is a special case
+    if sys.platform == "darwin" and sys.version_info[:2] >= (3, 6) and platform.machine() == "aarch64":
+        minimum_supported_numpy = "1.20.1"
 
     numpy_version = "numpy>=%s" % minimum_supported_numpy
 


### PR DESCRIPTION
Add rules for minimum `numpy` version for macOS aarch64. This does not solve https://github.com/opencv/opencv-python/issues/429 fully but should make it possible to build both `numpy` and `opencv-python` from sources on M1. See this comment: https://github.com/opencv/opencv-python/issues/429#issuecomment-806069540