### PR TITLE
Fix build for OSX ARM64 - platform says arm64, not aarch64. Also, set…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
   "setuptools", "wheel", "scikit-build", "cmake", "pip",
   "numpy==1.13.3; python_version=='3.6' and platform_machine != 'aarch64'",
   "numpy==1.19.3; python_version>='3.6' and sys_platform == 'linux' and platform_machine == 'aarch64'",
-  "numpy==1.20.1; python_version>='3.6' and sys_platform == 'darwin' and platform_machine == 'aarch64'",
+  "numpy==1.21.1; python_version>='3.6' and sys_platform == 'darwin' and platform_machine == 'arm64'",
   "numpy==1.14.5; python_version=='3.7' and platform_machine != 'aarch64'",
   "numpy==1.17.3; python_version=='3.8' and platform_machine != 'aarch64'",
   "numpy==1.19.3; python_version>='3.9' and platform_machine != 'aarch64'"

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ def main():
         minimum_supported_numpy = "1.19.3"
 
     # macos arm64 is a special case
-    if sys.platform == "darwin" and sys.version_info[:2] >= (3, 6) and platform.machine() == "aarch64":
-        minimum_supported_numpy = "1.20.1"
+    if sys.platform == "darwin" and sys.version_info[:2] >= (3, 6) and platform.machine() == "arm64":
+        minimum_supported_numpy = "1.21.1"
 
     numpy_version = "numpy>=%s" % minimum_supported_numpy
 


### PR DESCRIPTION
Fix local build for OS ARM64 as platform reports its name as 'arm64', not 'aarch64'. Also, increased numpy version, to avoid building it from sources.

What needs to be done is a CI step specific for OSX ARM64 - similar to what is done for windows