### PR TITLE
Upgrade to numpy 1.21 to prepare for Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,9 @@ requires = [
   "setuptools", "wheel", "scikit-build", "cmake", "pip",
   "numpy==1.13.3; python_version=='3.6' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
   "numpy==1.19.3; python_version>='3.6' and sys_platform == 'linux' and platform_machine == 'aarch64'",
-  "numpy==1.21.0; python_version>='3.6' and sys_platform == 'darwin' and platform_machine == 'arm64'",
+  "numpy==1.21.2; python_version>='3.6' and sys_platform == 'darwin' and platform_machine == 'arm64'",
   "numpy==1.14.5; python_version=='3.7' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
   "numpy==1.17.3; python_version=='3.8' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
-  "numpy==1.19.3; python_version>='3.9' and platform_machine != 'aarch64' and platform_machine != 'arm64'"
+  "numpy==1.19.3; python_version>='3.9' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
+  "numpy==1.21.2; python_version>='3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64'"
 ]

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,9 @@ def main():
         minimum_supported_numpy = "1.17.3"
     if sys.version_info[:2] >= (3, 9):
         minimum_supported_numpy = "1.19.3"
+    if sys.version_info[:2] >= (3, 10):
+        minimum_supported_numpy = "1.21.2"
+
 
     # linux arm64 is a special case
     if sys.platform.startswith("linux") and sys.version_info[:2] >= (3, 6) and platform.machine() == "aarch64":
@@ -37,7 +40,7 @@ def main():
 
     # macos arm64 is a special case
     if sys.platform == "darwin" and sys.version_info[:2] >= (3, 6) and platform.machine() == "arm64":
-        minimum_supported_numpy = "1.21.0"
+        minimum_supported_numpy = "1.21.2"
 
     numpy_version = "numpy>=%s" % minimum_supported_numpy
 


### PR DESCRIPTION
Fixes #525

Numpy's Python 3.10 statements at https://github.com/numpy/numpy/releases --> 1.21.2

Python 3.10 release candidate 2
https://www.python.org/downloads/release/python-3100rc2/
https://github.com/actions/python-versions/releases --> 3.10.0-rc.2

I am unclear how multibuild fits in https://anaconda.org/multibuild-wheels-staging/numpy/files