### PR TITLE
Python 3.10: Upgrade numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,10 @@
 requires = [
   "setuptools", "wheel", "scikit-build", "cmake", "pip",
   "numpy==1.13.3; python_version=='3.6' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
-  "numpy==1.19.3; python_version>='3.6' and sys_platform == 'linux' and platform_machine == 'aarch64'",
-  "numpy==1.21.0; python_version>='3.6' and sys_platform == 'darwin' and platform_machine == 'arm64'",
+  "numpy==1.21.2; python_version>='3.6' and sys_platform == 'linux' and platform_machine == 'aarch64'",
+  "numpy==1.21.2; python_version>='3.6' and sys_platform == 'darwin' and platform_machine == 'arm64'",
   "numpy==1.14.5; python_version=='3.7' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
   "numpy==1.17.3; python_version=='3.8' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
   "numpy==1.19.3; python_version>='3.9' and platform_machine != 'aarch64' and platform_machine != 'arm64'"
+  "numpy==1.21.2; python_version>='3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64'"
 ]


### PR DESCRIPTION
Fixes: #525
Fixes: #552

Redo of #539 now that Python 3.10 is released.

* https://pythoninsider.blogspot.com/2021/10/python-3100-is-available.html
* https://pypi.org/project/numpy