### PR TITLE
Updated opencv submodule for a tag and the description

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Python 3.x compatible pre-built wheels are provided for the officially supported
 - 3.7
 - 3.8
 - 3.9
+- 3.10
 
 ### Backward compatibility
 


### PR DESCRIPTION
Related to the https://github.com/opencv/opencv-python/pull/563#issuecomment-948846628 about a submodule commit.

Also updated the long description for the python 3.10 support.