### PR TITLE
Use PEP-508 compliant dependency specifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,26 +22,15 @@ def main():
     build_headless = get_build_env_var_by_name("headless")
     build_java = "ON" if get_build_env_var_by_name("java") else "OFF"
 
-    if sys.version_info[:2] >= (3, 6):
-        minimum_supported_numpy = "1.13.3"
-    if sys.version_info[:2] >= (3, 7):
-        minimum_supported_numpy = "1.14.5"
-    if sys.version_info[:2] >= (3, 8):
-        minimum_supported_numpy = "1.17.3"
-    if sys.version_info[:2] >= (3, 9):
-        minimum_supported_numpy = "1.19.3"
-    if sys.version_info[:2] >= (3, 10):
-        minimum_supported_numpy = "1.21.2"
-
-    # linux arm64 is a special case
-    if sys.platform.startswith("linux") and sys.version_info[:2] >= (3, 6) and platform.machine() == "aarch64":
-        minimum_supported_numpy = "1.19.3"
-
-    # macos arm64 is a special case
-    if sys.platform == "darwin" and sys.version_info[:2] >= (3, 6) and platform.machine() == "arm64":
-        minimum_supported_numpy = "1.21.0"
-
-    numpy_version = "numpy>=%s" % minimum_supported_numpy
+    install_requires = [
+        'numpy>=1.13.3; python_version<"3.7"',
+        'numpy>=1.14.5; python_version>="3.7"',
+        'numpy>=1.17.3; python_version>="3.8"',
+        'numpy>=1.19.3; python_version>="3.9"',
+        'numpy>=1.21.2; python_version>="3.10"',
+        'numpy>=1.19.3; python_version>="3.6" and platform_system=="Linux" and platform_machine=="aarch64"',
+        'numpy>=1.21.2; python_version>="3.6" and platform_system=="Darwin" and platform_machine=="arm64"',
+    ]
 
     python_version = cmaker.CMaker.get_python_version()
     python_lib_path = cmaker.CMaker.get_python_library(python_version).replace(
@@ -257,7 +246,7 @@ def main():
         package_data=package_data,
         maintainer="Olli-Pekka Heinisuo",
         ext_modules=EmptyListWithLength(),
-        install_requires=numpy_version,
+        install_requires=install_requires,
         python_requires=">=3.6",
         classifiers=[
             "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This allows correctly resolving the numpy version requirement via PyPI metadata, using the same metadata regardless of what version of Python the package was built with or which wheel is uploaded to PyPI first.

PEP 508: https://www.python.org/dev/peps/pep-0508/