### PR TITLE
Added python limited API support

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6']
         platform: [x64]
         with_contrib: [0, 1]
         without_gui: [0, 1]
@@ -37,13 +37,12 @@ jobs:
       MB_PYTHON_VERSION: ${{ matrix.python-version }}
       TRAVIS_PYTHON_VERSION: ${{ matrix.python-version }}
       MB_ML_VER: 2014
-      NP_TEST_DEP: numpy==1.19.4
-      NP_TEST_DEP_LATEST: numpy==1.21.2
       TRAVIS_BUILD_DIR: ${{ github.workspace }}
       CONFIG_PATH: travis_config.sh
       DOCKER_IMAGE: quay.io/asenyaev/manylinux2014_${PLAT}
       USE_CCACHE: 1
       UNICODE_WIDTH: 32
+      PLAT: x86_64
       SDIST: ${{ matrix.build_sdist || 0 }}
       ENABLE_HEADLESS: ${{ matrix.without_gui }}
       ENABLE_CONTRIB: ${{ matrix.with_contrib }}
@@ -59,25 +58,108 @@ jobs:
       if: github.event_name == 'pull_request'
       run: git submodule update --remote
 
-    - name: Setup Environment variables
-      run: |
-        if [ "schedule" == "${{ github.event_name }}" ]; then echo "TRAVIS_EVENT_TYPE=cron" >> $GITHUB_ENV; else echo "TRAVIS_EVENT_TYPE=${{ github.event_name }}" >> $GITHUB_ENV; fi
-        if [ "schedule" == "${{ github.event_name }}" ]; then echo "BUILD_COMMIT=master" >> $GITHUB_ENV; else echo "BUILD_COMMIT=$BUILD_COMMIT" >> $GITHUB_ENV; fi
-        if [ "x64" == "${{ matrix.platform }}" ]; then echo "PLAT=x86_64" >> $GITHUB_ENV; fi
-        if [ "3.10" == "${{ matrix.python-version }}" ]; then echo "TEST_DEPENDS=$(echo $NP_TEST_DEP_LATEST)" >> $GITHUB_ENV; else echo "TEST_DEPENDS=$(echo $NP_TEST_DEP)" >> $GITHUB_ENV; fi
-
-    - name: build
+    - name: Build a package
       run: source scripts/build.sh
 
-    - name: install and test
-      run: source scripts/install.sh
-
-    - name: saving artifacts
+    - name: Saving all wheels
       uses: actions/upload-artifact@v2
       with:
         name: wheels
         path: wheelhouse/opencv*.whl
 
+    - name: Saving opencv-python wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 0 }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-python-wheels
+        path: wheelhouse/opencv_python-*.whl
+
+    - name: Saving opencv-python-headless wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 0 }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-python-headless-wheels
+        path: wheelhouse/opencv_python_headless-*.whl
+
+    - name: Saving opencv-contrib-python wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 1 }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-contrib-python-wheels
+        path: wheelhouse/opencv_contrib_python-*.whl
+
+    - name: Saving opencv-contrib-python-headless wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 1 }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-contrib-python-headless-wheels
+        path: wheelhouse/opencv_contrib_python_headless-*.whl
+
+  test:
+    needs: [build]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        platform: [x64]
+        with_contrib: [0, 1]
+        without_gui: [0, 1]
+        build_sdist: [0]
+
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      MB_PYTHON_VERSION: ${{ matrix.python-version }}
+      NP_TEST_DEP: numpy==1.19.4
+      NP_TEST_DEP_LATEST: numpy==1.21.2
+      CONFIG_PATH: travis_config.sh
+      PLAT: x86_64
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: false
+        fetch-depth: 0
+
+    - name: Setup Environment variables
+      run: if [ "3.10" == "${{ matrix.python-version }}" ]; then echo "TEST_DEPENDS=$(echo $NP_TEST_DEP_LATEST)" >> $GITHUB_ENV; else echo "TEST_DEPENDS=$(echo $NP_TEST_DEP)" >> $GITHUB_ENV; fi
+
+    - name: Download opencv-python wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 0 }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-python-wheels
+        path: wheelhouse/
+
+    - name: Download opencv-python-headless wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 0 }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-python-headless-wheels
+        path: wheelhouse/
+
+    - name: Download opencv-contrib-python wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 1 }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-contrib-python-wheels
+        path: wheelhouse/
+
+    - name: Download opencv-contrib-python-headless wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 1 }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-contrib-python-headless-wheels
+        path: wheelhouse/
+
+    - name: Package installation and run tests
+      run: source scripts/install.sh
 
   build_sdist:
     runs-on: ${{ matrix.os }}
@@ -131,12 +213,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.platform }}
 
-    - name: Setup Environment variables
-      run: |
-        if [ "schedule" == "${{ github.event_name }}" ]; then echo "TRAVIS_EVENT_TYPE=cron" >> $GITHUB_ENV; else echo "TRAVIS_EVENT_TYPE=${{ github.event_name }}" >> $GITHUB_ENV; fi
-        if [ "schedule" == "${{ github.event_name }}" ]; then echo "BUILD_COMMIT=master" >> $GITHUB_ENV; else echo "BUILD_COMMIT=$BUILD_COMMIT" >> $GITHUB_ENV; fi
-
-    - name: before install
+    - name: Build a package
       run: |
         set -e
         # Build and package
@@ -157,7 +234,7 @@ jobs:
 
   test_release_opencv_python:
     if: github.event_name == 'release' && github.event.release.prerelease
-    needs: [build, build_sdist]
+    needs: [build, build_sdist, test]
     runs-on: ubuntu-latest
     environment: test-opencv-python-release
     defaults:
@@ -176,7 +253,7 @@ jobs:
 
   release_opencv_python:
     if: github.event_name == 'release' && !github.event.release.prerelease
-    needs: [build, build_sdist]
+    needs: [build, build_sdist, test]
     runs-on: ubuntu-latest
     environment: opencv-python-release
     defaults:

--- a/.github/workflows/build_wheels_linux_arm.yml
+++ b/.github/workflows/build_wheels_linux_arm.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ARM64]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6']
         platform: [x64]
         with_contrib: [0, 1]
         without_gui: [0, 1]
@@ -38,12 +38,9 @@ jobs:
       TRAVIS_PYTHON_VERSION: ${{ matrix.python-version }}
       PLAT: aarch64
       MB_ML_VER: 2014
-      NP_TEST_DEP: numpy==1.19.4
-      NP_TEST_DEP_LATEST: numpy==1.21.2
       TRAVIS_BUILD_DIR: ${{ github.workspace }}
       CONFIG_PATH: travis_config.sh
       DOCKER_IMAGE: quay.io/asenyaev/manylinux2014_${PLAT}
-      DOCKER_TEST_IMAGE: multibuild/focal_arm64v8
       USE_CCACHE: 0
       UNICODE_WIDTH: 32
       SDIST: ${{ matrix.build_sdist || 0 }}
@@ -61,26 +58,118 @@ jobs:
         submodules: false
         fetch-depth: 0
 
-    - name: Setup Environment variables
-      run: |
-        if [ "ARM64" == "${{ matrix.os }}" ]; then echo "PLAT=aarch64" >> $GITHUB_ENV; fi
-        if [ "3.10" == "${{ matrix.python-version }}" ]; then echo "TEST_DEPENDS=$(echo $NP_TEST_DEP_LATEST)" >> $GITHUB_ENV; else echo "TEST_DEPENDS=$(echo $NP_TEST_DEP)" >> $GITHUB_ENV; fi
-
-    - name: build
+    - name: Build a package
       run: source scripts/build.sh
 
-    - name: install and test
-      run: source scripts/install.sh
-
-    - name: saving artifacts
+    - name: Saving all wheels
       uses: actions/upload-artifact@v2
       with:
         name: wheels
         path: wheelhouse/opencv*.whl
 
+    - name: Saving opencv-python wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 0 }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-python-wheels
+        path: wheelhouse/opencv_python-*.whl
+
+    - name: Saving opencv-python-headless wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 0 }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-python-headless-wheels
+        path: wheelhouse/opencv_python_headless-*.whl
+
+    - name: Saving opencv-contrib-python wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 1 }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-contrib-python-wheels
+        path: wheelhouse/opencv_contrib_python-*.whl
+
+    - name: Saving opencv-contrib-python-headless wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 1 }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-contrib-python-headless-wheels
+        path: wheelhouse/opencv_contrib_python_headless-*.whl
+
+  test:
+    needs: [build_arm]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ARM64]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        platform: [x64]
+        with_contrib: [0, 1]
+        without_gui: [0, 1]
+        build_sdist: [0]
+
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      MB_PYTHON_VERSION: ${{ matrix.python-version }}
+      PLAT: aarch64
+      NP_TEST_DEP: numpy==1.19.4
+      NP_TEST_DEP_LATEST: numpy==1.21.4
+      CONFIG_PATH: travis_config.sh
+      DOCKER_TEST_IMAGE: multibuild/focal_arm64v8
+      UNICODE_WIDTH: 32
+
+    steps:
+    - name: Cleanup
+      if: always()
+      uses: AutoModality/action-clean@v1
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
+
+    - name: Setup Environment variables
+      run: if [ "3.10" == "${{ matrix.python-version }}" ]; then echo "TEST_DEPENDS=$(echo $NP_TEST_DEP_LATEST)" >> $GITHUB_ENV; else echo "TEST_DEPENDS=$(echo $NP_TEST_DEP)" >> $GITHUB_ENV; fi
+
+    - name: Download opencv-python wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 0 }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-python-wheels
+        path: wheelhouse/
+
+    - name: Download opencv-python-headless wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 0 }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-python-headless-wheels
+        path: wheelhouse/
+
+    - name: Download opencv-contrib-python wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 1 }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-contrib-python-wheels
+        path: wheelhouse/
+
+    - name: Download opencv-contrib-python-headless wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 1 }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-contrib-python-headless-wheels
+        path: wheelhouse/
+
+    - name: Package installation and run tests
+      run: source scripts/install.sh
+
   test_release_opencv_python:
     if: github.event_name == 'release' && github.event.release.prerelease
-    needs: [build_arm]
+    needs: [build_arm, test]
     runs-on: ubuntu-latest
     environment: test-opencv-python-release
     defaults:
@@ -99,7 +188,7 @@ jobs:
 
   release_opencv_python:
     if: github.event_name == 'release' && !github.event.release.prerelease
-    needs: [build_arm]
+    needs: [build_arm, test]
     runs-on: ubuntu-latest
     environment: opencv-python-release
     defaults:

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-10.15, macos-11]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6']
         platform: [x64]
         with_contrib: [0, 1]
         without_gui: [0, 1]
@@ -48,14 +48,13 @@ jobs:
       MB_PYTHON_VERSION: ${{ matrix.python-version }}
       TRAVIS_PYTHON_VERSION: ${{ matrix.python-version }}
       MB_ML_VER: 2014
-      NP_TEST_DEP: numpy==1.19.4
-      NP_TEST_DEP_LATEST: numpy==1.21.2
       TRAVIS_BUILD_DIR: ${{ github.workspace }}
       TRAVIS_OS_NAME: osx
       CONFIG_PATH: travis_config.sh
       DOCKER_IMAGE: quay.io/asenyaev/manylinux2014_${PLAT}
       USE_CCACHE: 1
       UNICODE_WIDTH: 32
+      PLAT: x86_64
       SDIST: ${{ matrix.build_sdist || 0 }}
       ENABLE_HEADLESS: ${{ matrix.without_gui }}
       ENABLE_CONTRIB: ${{ matrix.with_contrib }}
@@ -71,15 +70,7 @@ jobs:
       if: github.event_name == 'pull_request'
       run: git submodule update --remote
 
-    - name: Setup Environment variables
-      run: |
-        if [ "schedule" == "${{ github.event_name }}" ]; then echo "TRAVIS_EVENT_TYPE=cron" >> $GITHUB_ENV; else echo "TRAVIS_EVENT_TYPE=${{ github.event_name }}" >> $GITHUB_ENV; fi
-        if [ "schedule" == "${{ github.event_name }}" ]; then echo "BUILD_COMMIT=master" >> $GITHUB_ENV; else echo "BUILD_COMMIT=$BUILD_COMMIT" >> $GITHUB_ENV; fi
-        if [ "x64" == "${{ matrix.platform }}" ]; then echo "PLAT=x86_64" >> $GITHUB_ENV; fi
-        if [ "x86" == "${{ matrix.platform }}" ]; then echo "PLAT=i686" >> $GITHUB_ENV; fi
-        if [ "3.10" == "${{ matrix.python-version }}" ]; then echo "TEST_DEPENDS=$(echo $NP_TEST_DEP_LATEST)" >> $GITHUB_ENV; else echo "TEST_DEPENDS=$(echo $NP_TEST_DEP)" >> $GITHUB_ENV; fi
-
-    - name: before install
+    - name: Build a package
       run: |
         set -e
         # Check out and prepare the source
@@ -96,19 +87,136 @@ jobs:
         echo $ENABLE_HEADLESS > headless.enabled
         set -x
         build_wheel $REPO_DIR $PLAT
-        git submodule update --init --recursive
-        install_run $PLAT
-        set +x
 
-    - name: saving artifacts
+    - name: Saving all wheels
       uses: actions/upload-artifact@v2
       with:
         name: wheels
         path: wheelhouse/opencv*.whl
 
+    - name: Saving opencv-python wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 0 }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-python-wheels
+        path: wheelhouse/opencv_python-*.whl
+
+    - name: Saving opencv-python-headless wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 0 }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-python-headless-wheels
+        path: wheelhouse/opencv_python_headless-*.whl
+
+    - name: Saving opencv-contrib-python wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 1 }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-contrib-python-wheels
+        path: wheelhouse/opencv_contrib_python-*.whl
+
+    - name: Saving opencv-contrib-python-headless wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 1 }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-contrib-python-headless-wheels
+        path: wheelhouse/opencv_contrib_python_headless-*.whl
+
+  test:
+    needs: [build]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-10.15, macos-11]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        platform: [x64]
+        with_contrib: [0, 1]
+        without_gui: [0, 1]
+        build_sdist: [0]
+        exclude:
+          - os: macos-10.15
+            python-version: '3.10'
+          - os: macos-11
+            python-version: '3.6'
+          - os: macos-11
+            python-version: '3.7'
+          - os: macos-11
+            python-version: '3.8'
+          - os: macos-11
+            python-version: '3.9'
+
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      MB_PYTHON_VERSION: ${{ matrix.python-version }}
+      NP_TEST_DEP: numpy==1.19.4
+      NP_TEST_DEP_LATEST: numpy==1.21.4
+      CONFIG_PATH: travis_config.sh
+      PLAT: x86_64
+      OPENCV_TEST_DATA_PATH: ${{ github.workspace }}/opencv_extra/testdata
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.platform }}
+
+    - name: Setup Environment variables
+      run: if [ "3.10" == "${{ matrix.python-version }}" ]; then echo "TEST_DEPENDS=$(echo $NP_TEST_DEP_LATEST)" >> $GITHUB_ENV; else echo "TEST_DEPENDS=$(echo $NP_TEST_DEP)" >> $GITHUB_ENV; fi
+
+    - name: Download opencv-python wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 0 }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-python-wheels
+        path: wheelhouse/
+
+    - name: Download opencv-python-headless wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 0 }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-python-headless-wheels
+        path: wheelhouse/
+
+    - name: Download opencv-contrib-python wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 1 }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-contrib-python-wheels
+        path: wheelhouse/
+
+    - name: Download opencv-contrib-python-headless wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 1 }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-contrib-python-headless-wheels
+        path: wheelhouse/
+
+    - name: Package installation
+      run: |
+        python -m pip install wheelhouse/opencv*.whl
+        cd ${{ github.workspace }}/tests
+        python get_build_info.py
+
+    - name: Run tests
+      run: |
+        cd ${{ github.workspace }}/opencv
+        python modules/python/test/test.py -v --repo .
+
   test_release_opencv_python:
     if: github.event_name == 'release' && github.event.release.prerelease
-    needs: [build]
+    needs: [build, test]
     runs-on: ubuntu-latest
     environment: test-opencv-python-release
     defaults:
@@ -127,7 +235,7 @@ jobs:
 
   release_opencv_python:
     if: github.event_name == 'release' && !github.event.release.prerelease
-    needs: [build]
+    needs: [build, test]
     runs-on: ubuntu-latest
     environment: opencv-python-release
     defaults:

--- a/.github/workflows/build_wheels_macos_m1.yml
+++ b/.github/workflows/build_wheels_macos_m1.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-M1]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7']
         platform: [x64]
         with_contrib: [0, 1]
         without_gui: [0, 1]
@@ -31,7 +31,6 @@ jobs:
       SDIST: ${{ matrix.build_sdist || 0 }}
       ENABLE_HEADLESS: ${{ matrix.without_gui }}
       ENABLE_CONTRIB: ${{ matrix.with_contrib }}
-      OPENCV_TEST_DATA_PATH: ${{ github.workspace }}/opencv_extra/testdata
 
     steps:
     - name: Checkout
@@ -44,36 +43,116 @@ jobs:
       if: github.event_name == 'pull_request'
       run: git submodule update --remote
 
-    - name: build script
+    - name: Build a package
       run: |
         git submodule update --init multibuild
         echo $ENABLE_CONTRIB > contrib.enabled
         echo $ENABLE_HEADLESS > headless.enabled
         export MACOSX_DEPLOYMENT_TARGET=11.0
-        arch -arm64 python${{ matrix.python-version }} -m pip wheel --wheel-dir=wheelhouse . --verbose
+        arch -arm64 python${{ matrix.python-version }} -m pip install toml && python${{ matrix.python-version }} -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | python${{ matrix.python-version }} -m pip install -r /dev/stdin
+        arch -arm64 python${{ matrix.python-version }} setup.py bdist_wheel --py-limited-api=cp37 --dist-dir=wheelhouse -v
         delocate-wheel ${{ github.workspace }}/wheelhouse/opencv*
 
-    - name: before test
-      run: |
-        git submodule update --init --recursive
-        arch -arm64 python${{ matrix.python-version }} -m pip install --user --no-cache --force-reinstall wheelhouse/opencv*.whl
-        cd ${{ github.workspace }}/tests
-        arch -arm64 python${{ matrix.python-version }} get_build_info.py
-
-    - name: run test
-      run: |
-        cd ${{ github.workspace }}/opencv
-        arch -arm64 python${{ matrix.python-version }} modules/python/test/test.py -v --repo .
-
-    - name: saving artifacts
+    - name: Saving all wheels
       uses: actions/upload-artifact@v2
       with:
         name: wheels
         path: wheelhouse/opencv*.whl
 
+    - name: Saving opencv-python wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 0 }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-python-wheels
+        path: wheelhouse/opencv_python-*.whl
+
+    - name: Saving opencv-python-headless wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 0 }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-python-headless-wheels
+        path: wheelhouse/opencv_python_headless-*.whl
+
+    - name: Saving opencv-contrib-python wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 1 }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-contrib-python-wheels
+        path: wheelhouse/opencv_contrib_python-*.whl
+
+    - name: Saving opencv-contrib-python-headless wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 1 }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-contrib-python-headless-wheels
+        path: wheelhouse/opencv_contrib_python_headless-*.whl
+
+  test:
+    needs: [build]
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macOS-M1]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+        platform: [x64]
+        with_contrib: [0, 1]
+        without_gui: [0, 1]
+        build_sdist: [0]
+
+    env:
+      OPENCV_TEST_DATA_PATH: ${{ github.workspace }}/opencv_extra/testdata
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
+
+    - name: Download opencv-python wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 0 }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-python-wheels
+        path: wheelhouse/
+
+    - name: Download opencv-python-headless wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 0 }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-python-headless-wheels
+        path: wheelhouse/
+
+    - name: Download opencv-contrib-python wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 1 }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-contrib-python-wheels
+        path: wheelhouse/
+
+    - name: Download opencv-contrib-python-headless wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 1 }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-contrib-python-headless-wheels
+        path: wheelhouse/
+
+    - name: Package installation
+      run: |
+        arch -arm64 python${{ matrix.python-version }} -m pip install --user --no-cache --force-reinstall wheelhouse/opencv*.whl
+        cd ${{ github.workspace }}/tests
+        arch -arm64 python${{ matrix.python-version }} get_build_info.py
+
+    - name: Run tests
+      run: |
+        cd ${{ github.workspace }}/opencv
+        arch -arm64 python${{ matrix.python-version }} modules/python/test/test.py -v --repo .
+
   test_release_opencv_python:
     if: github.event_name == 'release' && github.event.release.prerelease
-    needs: [build]
+    needs: [build, test]
     runs-on: ubuntu-latest
     environment: test-opencv-python-release
     defaults:
@@ -92,7 +171,7 @@ jobs:
 
   release_opencv_python:
     if: github.event_name == 'release' && !github.event.release.prerelease
-    needs: [build]
+    needs: [build, test]
     runs-on: ubuntu-latest
     environment: opencv-python-release
     defaults:

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6']
         platform: [x86, x64]
         with_contrib: [0, 1]
         without_gui: [0, 1]
@@ -55,38 +55,184 @@ jobs:
     - name: Setup MSBuild.exe
       uses: warrenbuckley/Setup-MSBuild@v1
 
-    - name: build script
+    - name: Build a package
       run: |
         python --version
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools
-        set "CI_BUILD=1" && python -m pip wheel --wheel-dir=%cd%\wheelhouse . --verbose
+        python -m pip install toml && python -c "import toml; c = toml.load('pyproject.toml'); print('\n'.join(c['build-system']['requires']))" >> requirements.txt | python -m pip install -r requirements.txt
+        set "CI_BUILD=1" && python setup.py bdist_wheel --py-limited-api=cp36 --dist-dir=%cd%\wheelhouse -v
       shell: cmd
 
-    - name: before test
+    - name: Saving all wheels
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheels
+        path: wheelhouse/opencv*.whl
+
+    - name: Saving opencv-python x86 wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 0 && matrix.platform == 'x86' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-python-wheels-x86
+        path: wheelhouse/opencv_python-*.whl
+
+    - name: Saving opencv-python x64 wheels  
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 0 && matrix.platform == 'x64' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-python-wheels-x64
+        path: wheelhouse/opencv_python-*.whl
+
+    - name: Saving opencv-python-headless x86 wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 0 && matrix.platform == 'x86' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-python-headless-wheels-x86
+        path: wheelhouse/opencv_python_headless-*.whl
+
+    - name: Saving opencv-python-headless x64 wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 0 && matrix.platform == 'x64' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-python-headless-wheels-x64
+        path: wheelhouse/opencv_python_headless-*.whl
+
+    - name: Saving opencv-contrib-python x86 wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 1 && matrix.platform == 'x86' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-contrib-python-wheels-x86
+        path: wheelhouse/opencv_contrib_python-*.whl
+
+    - name: Saving opencv-contrib-python x64 wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 1 && matrix.platform == 'x64' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-contrib-python-wheels-x64
+        path: wheelhouse/opencv_contrib_python-*.whl
+
+    - name: Saving opencv-contrib-python-headless x86 wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 1 && matrix.platform == 'x86' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-contrib-python-headless-wheels-x86
+        path: wheelhouse/opencv_contrib_python_headless-*.whl
+
+    - name: Saving opencv-contrib-python-headless x64 wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 1 && matrix.platform == 'x64' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: opencv-contrib-python-headless-wheels-x64
+        path: wheelhouse/opencv_contrib_python_headless-*.whl
+
+  test:
+    needs: [build-windows-x86_64]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: powershell
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        platform: [x86, x64]
+        with_contrib: [0, 1]
+        without_gui: [0, 1]
+        build_sdist: [0]
+
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      OPENCV_TEST_DATA_PATH: ${{ github.workspace }}\opencv_extra\testdata
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.platform }}
+
+    - name: Download opencv-python x86 wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 0 && matrix.platform == 'x86' }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-python-wheels-x86
+        path: wheelhouse/
+
+    - name: Download opencv-python x64 wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 0 && matrix.platform == 'x64' }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-python-wheels-x64
+        path: wheelhouse/
+
+    - name: Download opencv-python-headless x86 wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 0 && matrix.platform == 'x86' }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-python-headless-wheels-x86
+        path: wheelhouse/
+
+    - name: Download opencv-python-headless x64 wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 0 && matrix.platform == 'x64' }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-python-headless-wheels-x64
+        path: wheelhouse/
+
+    - name: Download opencv-contrib-python x86 wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 1 && matrix.platform == 'x86' }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-contrib-python-wheels-x86
+        path: wheelhouse/
+
+    - name: Download opencv-contrib-python x64 wheels
+      if: ${{ matrix.without_gui == 0 && matrix.with_contrib == 1 && matrix.platform == 'x64' }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-contrib-python-wheels-x64
+        path: wheelhouse/
+
+    - name: Download opencv-contrib-python-headless x86 wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 1 && matrix.platform == 'x86' }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-contrib-python-headless-wheels-x86
+        path: wheelhouse/
+
+    - name: Download opencv-contrib-python-headless x64 wheels
+      if: ${{ matrix.without_gui == 1 && matrix.with_contrib == 1 && matrix.platform == 'x64' }}
+      uses: actions/download-artifact@v2
+      with:
+        name: opencv-contrib-python-headless-wheels-x64
+        path: wheelhouse/
+
+    - name: Package installation
       run: |
-        git submodule update --init --recursive
         cd ${{ github.workspace }}/tests
         &python -m pip install --user --no-warn-script-location (ls "../wheelhouse/opencv*.whl")
         if ($LastExitCode -ne 0) {throw $LastExitCode}
         python get_build_info.py
       shell: powershell
 
-    - name: run test
+    - name: Run tests
       run: |
         cd ${{ github.workspace }}/opencv
         python modules\python\test\test.py -v --repo .
       shell: cmd
 
-    - name: saving artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: wheels
-        path: wheelhouse/opencv*.whl
-
   test_release_opencv_python:
     if: github.event_name == 'release' && github.event.release.prerelease
-    needs: [build-windows-x86_64]
+    needs: [build-windows-x86_64, test]
     runs-on: ubuntu-latest
     environment: test-opencv-python-release
     defaults:
@@ -105,7 +251,7 @@ jobs:
 
   release_opencv_python:
     if: github.event_name == 'release' && !github.event.release.prerelease
-    needs: [build-windows-x86_64]
+    needs: [build-windows-x86_64, test]
     runs-on: ubuntu-latest
     environment: opencv-python-release
     defaults:

--- a/setup.py
+++ b/setup.py
@@ -97,8 +97,8 @@ def main():
         # Naming conventions vary so widely between versions and OSes
         # had to give up on checking them.
         [
-            "python/cv2/python-%s.%s/cv2[^/]*%s"
-            % (sys.version_info[0], sys.version_info[1], re.escape(sysconfig.get_config_var("EXT_SUFFIX")))
+            r"python/cv2/python-%s/cv2.*"
+            % (sys.version_info[0])
         ]
         +
         [
@@ -159,6 +159,7 @@ def main():
             "-DBUILD_TESTS=OFF",
             "-DBUILD_PERF_TESTS=OFF",
             "-DBUILD_DOCS=OFF",
+            "-DPYTHON3_LIMITED_API=ON",
         ]
         + (
             # If it is not defined 'linker flags: /machine:X86' on Windows x64
@@ -370,7 +371,7 @@ class RearrangeCMakeOutput(object):
         with open(os.path.join(cmake_install_dir, "python", "cv2", "__init__.py"), 'r') as opencv_init:
             opencv_init_lines = opencv_init.readlines()
             extra_imports = ('\nfrom .cv2 import *\nfrom .cv2 import _registerMatType\nfrom . import mat_wrapper\nfrom . import gapi'
-                             '\nfrom . import misc\nfrom . import utils\nfrom . import data\n')
+                             '\nfrom . import misc\nfrom . import utils\nfrom . import data\nfrom . import version\n')
             free_line_after_imports = 6
             opencv_init_lines.insert(free_line_after_imports, extra_imports)
             opencv_init_data = ""

--- a/travis_config.sh
+++ b/travis_config.sh
@@ -14,7 +14,9 @@ function bdist_wheel_cmd {
     # copied from multibuild's common_utils.sh
     # add osx deployment target so it doesn't default to 10.6
     local abs_wheelhouse=$1
-    CI_BUILD=1 pip wheel --verbose --wheel-dir="$PWD/dist" . $BDIST_PARAMS
+    # install all required packages in pyproject.toml, because bdist_wheel does not do it
+    python${PYTHON_VERSION} -m pip install toml && python${PYTHON_VERSION} -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | python${PYTHON_VERSION} -m pip install -r /dev/stdin
+    CI_BUILD=1 python${PYTHON_VERSION} setup.py bdist_wheel --py-limited-api=cp36 -v
     cp dist/*.whl $abs_wheelhouse
     if [ -z "$IS_OSX" ]; then
       # this path can be changed in the latest manylinux image
@@ -22,8 +24,6 @@ function bdist_wheel_cmd {
       /opt/python/cp39-cp39/bin/python -m venv $TOOLS_PATH
       source $TOOLS_PATH/bin/activate
       python patch_auditwheel_whitelist.py
-      # to avoid issues with numpy wheels
-      rm /io/wheelhouse/numpy*
       deactivate
     fi
     if [ -n "$USE_CCACHE" -a -z "$BREW_BOOTSTRAP_MODE" ]; then ccache -s; fi


### PR DESCRIPTION
- Added `"DPYTHON3_LIMITED_API=ON"` flag in `setup.py`
- Changed the pattern to save a binary in `setup.py`
- Added a proper import `version.py` in `setup.py` after moving to python limited API
- Changed the command to build a package in `travis_config.sh`
- Modified workflows for all platforms to build packages on one python version and then to test it on all combinations.

Also PR fixes an issue: https://github.com/opencv/opencv-python/issues/414