### PR TITLE
allow numpy 2.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,9 @@ def main():
     build_java = "ON" if get_build_env_var_by_name("java") else "OFF"
     build_rolling = get_build_env_var_by_name("rolling")
 
-    # NOTE: since 2.3.0 numpy upgraded from manylinux2014 to manylinux_2_28
-    # see https://numpy.org/doc/stable/release/2.3.0-notes.html#numpy-2-3-0-release-notes
     install_requires = [
         'numpy<2.0; python_version<"3.9"',
-        'numpy(>=2, <2.3.0); python_version>="3.9"',
+        'numpy>=2; python_version>="3.9"',
     ]
 
     python_version = cmaker.CMaker.get_python_version()


### PR DESCRIPTION
This PR relaxes the runtime numpy dependency to allow the latest released minor version (2.3.x).

~This follows the recommendations linked in https://github.com/opencv/opencv-python/pull/1119 (which added the runtime upper pin) and updates the pin based on the latest released version.~ EDIT: see https://github.com/opencv/opencv-python/pull/1142#discussion_r2352128587 for discussion on pin


issue #1140 #1135