### PR TITLE
fix: add explicit NumPy version constraints for Python 3.13+ and 3.14 (NumPy 2.x compatibility)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,9 @@ def main():
 
     install_requires = [
         'numpy<2.0; python_version<"3.9"',
-        'numpy>=2.0.2; python_version>="3.9" and python_version<"3.13"',
-        'numpy>=2.1.3; python_version>="3.13" and python_version<"3.14"',
-        'numpy>=2.3.0; python_version>="3.14"',
+        'numpy>=2.0; python_version>="3.9" and python_version<"3.13"',
+        'numpy>=2.1; python_version>="3.13" and python_version<"3.14"',
+        'numpy>=2.3.2; python_version>="3.14"',
     ]
 
     python_version = cmaker.CMaker.get_python_version()

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,9 @@ def main():
 
     install_requires = [
         'numpy<2.0; python_version<"3.9"',
-        'numpy>=2; python_version>="3.9"',
+        'numpy>=2.0.2; python_version>="3.9" and python_version<"3.13"',
+        'numpy>=2.1.3; python_version>="3.13" and python_version<"3.14"',
+        'numpy>=2.3.0; python_version>="3.14"',
     ]
 
     python_version = cmaker.CMaker.get_python_version()


### PR DESCRIPTION
## Summary
- Fix NumPy 2.x ABI compatibility issue for Python 3.13+ and 3.14
- Changed  to specify explicit minimum NumPy versions per Python version
- This resolves the runtime error where wheels compiled against NumPy 1.x fail when used with NumPy 2.x

## Changes
- Python 3.9-3.12: 
- Python 3.13: 
- Python 3.14+: 

## Root Cause
The wheel metadata declared  as dependency at install time, but the compiled wheels may have been built against NumPy 1.x headers, causing ABI incompatibility at runtime.

Fixes #1201