### PR TITLE
Use trusted publishing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Please see the documentation for more information:
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    assignees:
+      - kohtala

--- a/.github/workflows/build_sdist.yml
+++ b/.github/workflows/build_sdist.yml
@@ -1,0 +1,83 @@
+name: Build sdist
+
+on:
+  pull_request:
+    branches:
+    - 4.x
+    - 5.x
+    paths-ignore:
+    - '.github/workflows/build_wheels_*'
+    - '.github/workflows/release.yml'
+  workflow_call:
+    inputs:
+      rolling:
+        type: boolean
+        default: false
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  Build_sdist:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.8]
+        platform: [x64]
+        with_contrib: [0, 1]
+        without_gui: [0, 1]
+        build_sdist: [1]
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      REPO_DIR: .
+      PROJECT_SPEC: opencv-python
+      PLAT: x86_64
+      MB_PYTHON_VERSION: ${{ matrix.python-version }}
+      TRAVIS_PYTHON_VERSION: ${{ matrix.python-version }}
+      MB_ML_VER: 2014
+      NP_TEST_DEP: numpy==1.19.4
+      TRAVIS_BUILD_DIR: ${{ github.workspace }}
+      CONFIG_PATH: travis_config.sh
+      DOCKER_IMAGE: quay.io/opencv-ci/opencv-python-manylinux2014-x86-64:20260725@sha256:b31dbd9260993812b011eeea543fe3bad30cd1803dd54963ffd74bb4b7e31f38
+      USE_CCACHE: 1
+      UNICODE_WIDTH: 32
+      SDIST: ${{ matrix.build_sdist || 0 }}
+      ENABLE_HEADLESS: ${{ matrix.without_gui || 0 }}
+      ENABLE_CONTRIB: ${{ matrix.with_contrib || 0 }}
+    steps:
+    - name: Cleanup
+      run: find . -mindepth 1 -delete
+      working-directory: ${{ github.workspace }}
+    - name: Setup environment
+      if: inputs.rolling == 'true' || github.event_name == 'workflow_dispatch'
+      run: |
+        echo "ENABLE_ROLLING=1" >> $GITHUB_ENV
+    - name: Checkout
+      uses: actions/checkout@v7
+      with:
+        submodules: false
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v7
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.platform }}
+    - name: Build a package
+      run: |
+        set -e
+        # Build and package
+        set -x
+          python -m pip install --upgrade pip
+          python -m pip install scikit-build
+          python setup.py sdist --formats=gztar
+        set +x
+        # Install and run tests
+        set -x
+        echo "skipping tests because of sdist"
+    - name: saving artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name: build-${{ matrix.platform }}-sdist-${{ matrix.with_contrib }}-${{ matrix.without_gui }}-${{ matrix.build_sdist }}
+        path: dist/opencv*.tar.gz

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -9,16 +9,21 @@ on:
       - '.github/workflows/build_wheels_manylinux*'
       - '.github/workflows/build_wheels_windows*'
       - '.github/workflows/build_wheels_macos_m1.yml'
-  release:
-    types: [published, edited]
-  schedule:
-    - cron: '0 3 * * 6'
+      - '.github/workflows/build_sdist.yml'
+      - '.github/workflows/release.yml'
+  workflow_call:
+    inputs:
+      rolling:
+        type: boolean
+        default: false
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 jobs:
   Build:
-    runs-on: python-macos-intel
+    runs-on: macos-15-intel
     strategy:
       fail-fast: false
       matrix:
@@ -46,37 +51,38 @@ jobs:
       ENABLE_CONTRIB: ${{ matrix.with_contrib }}
       PIP_INDEX_URL: https://pypi.tuna.tsinghua.edu.cn/simple
     steps:
-    - name: Cleanup
-      run: find . -mindepth 1 -delete
-      working-directory: ${{ github.workspace }}
     - name: Setup environment
+      if: inputs.rolling == 'true' || github.event_name == 'workflow_dispatch'
       run: |
-        if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-          echo "ENABLE_ROLLING=1" >> $GITHUB_ENV
-        fi
+        echo "ENABLE_ROLLING=1" >> $GITHUB_ENV
     - name: Checkout
       uses: actions/checkout@v7
       with:
         submodules: false
         fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v7
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.platform }}
     - name: Build a package
       run: |
         git submodule update --init multibuild
         echo $ENABLE_CONTRIB > contrib.enabled
         echo $ENABLE_HEADLESS > headless.enabled
         export MACOSX_DEPLOYMENT_TARGET=14.0
-        python${{ matrix.python-version }} -m pip install toml && python${{ matrix.python-version }} -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | python${{ matrix.python-version }} -m pip install -r /dev/stdin
-        python${{ matrix.python-version }} setup.py bdist_wheel --py-limited-api=cp37 --dist-dir=wheelhouse -v
+        python -m pip install toml && python -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | python -m pip install -r /dev/stdin
+        python setup.py bdist_wheel --py-limited-api=cp37 --dist-dir=wheelhouse -v
         delocate-wheel ${{ github.workspace }}/wheelhouse/opencv*
     - name: Saving a wheel accordingly to matrix
       uses: actions/upload-artifact@v7
       with:
-        name: wheel-${{ matrix.with_contrib }}-${{ matrix.without_gui }}-${{ matrix.build_sdist }}
+        name: build-${{ matrix.platform }}-macos-${{ matrix.with_contrib }}-${{ matrix.without_gui }}-${{ matrix.build_sdist }}
         path: wheelhouse/opencv*.whl
 
   Test:
     needs: [Build]
-    runs-on: python-macos-intel
+    runs-on: macos-26-intel
     strategy:
       fail-fast: false
       matrix:
@@ -107,104 +113,32 @@ jobs:
     - name: Download a wheel accordingly to matrix
       uses: actions/download-artifact@v8
       with:
-        name: wheel-${{ matrix.with_contrib }}-${{ matrix.without_gui }}-${{ matrix.build_sdist }}
+        name: build-${{ matrix.platform }}-macos-${{ matrix.with_contrib }}-${{ matrix.without_gui }}-${{ matrix.build_sdist }}
         path: wheelhouse/
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v7
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.platform }}
     - name: Create Venv for test
       run: |
         test -d "${{ github.workspace }}/opencv_test" && rm -rf "${{ github.workspace }}/opencv_test"
-        python${{ matrix.python-version }} -m venv ${{ github.workspace }}/opencv_test
+        python -m venv ${{ github.workspace }}/opencv_test
     - name: Package installation
       run: |
         source ${{ github.workspace }}/opencv_test/bin/activate
-        python${{ matrix.python-version }} -m pip install --upgrade pip
-        python${{ matrix.python-version }} -m pip install --no-cache --force-reinstall wheelhouse/opencv*.whl
+        python -m pip install --upgrade pip
+        python -m pip install --no-cache --force-reinstall wheelhouse/opencv*.whl
         cd ${{ github.workspace }}/tests
-        python${{ matrix.python-version }} get_build_info.py
+        python get_build_info.py
     - name: Run tests
       run: |
         source ${{ github.workspace }}/opencv_test/bin/activate
         cd ${{ github.workspace }}/opencv
-        python${{ matrix.python-version }} modules/python/test/test.py -v --repo .
+        python modules/python/test/test.py -v --repo .
     - name: Pylint test
       run: |
         source ${{ github.workspace }}/opencv_test/bin/activate
-        python${{ matrix.python-version }} -m pip install pylint==2.15.9
+        python -m pip install pylint==2.15.9
         cd ${{ github.workspace }}/tests
-        python${{ matrix.python-version }} -m pylint $PYLINT_TEST_FILE
-
-  Release_rolling:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-    needs: [Build, Test]
-    runs-on: ubuntu-22.04
-    environment: opencv-python-rolling-release
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          name: wheels
-          path: wheelhouse/
-      - name: Upload wheels for opencv_python_rolling
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_PYTHON_ROLLING_USERNAME }} -p ${{ secrets.OPENCV_PYTHON_ROLLING_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_python_rolling-*
-      - name: Upload wheels for opencv_contrib_python_rolling
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_CONTRIB_PYTHON_ROLLING_USERNAME }} -p ${{ secrets.OPENCV_CONTRIB_PYTHON_ROLLING_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_contrib_python_rolling-*
-      - name: Upload wheels for opencv_python_headless_rolling
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_PYTHON_HEADLESS_ROLLING_USERNAME }} -p ${{ secrets.OPENCV_PYTHON_HEADLESS_ROLLING_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_python_headless_rolling-*
-      - name: Upload wheels for opencv_contrib_python_headless_rolling
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_CONTRIB_PYTHON_HEADLESS_ROLLING_USERNAME }} -p ${{ secrets.OPENCV_CONTRIB_PYTHON_HEADLESS_ROLLING_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_contrib_python_headless_rolling-*
-
-  Pre-release:
-    if: github.event_name == 'release' && github.event.release.prerelease
-    needs: [Build, Test]
-    runs-on: ubuntu-22.04
-    environment: test-opencv-python-release
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: wheelhouse/
-      - name: Upload all wheels
-        run: |
-          tree
-          python -m pip install twine
-          python -m twine upload --repository testpypi -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_*
-
-  Release:
-    if: github.event_name == 'release' && !github.event.release.prerelease
-    needs: [Build, Test]
-    runs-on: ubuntu-22.04
-    environment: opencv-python-release
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: wheelhouse/
-      - name: Upload wheels for opencv_python
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_PYTHON_USERNAME }} -p ${{ secrets.OPENCV_PYTHON_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_python-*
-      - name: Upload wheels for opencv_contrib_python
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_CONTRIB_PYTHON_USERNAME }} -p ${{ secrets.OPENCV_CONTRIB_PYTHON_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_contrib_python-*
-      - name: Upload wheels for opencv_python_headless
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_PYTHON_HEADLESS_USERNAME }} -p ${{ secrets.OPENCV_PYTHON_HEADLESS_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_python_headless-*
-      - name: Upload wheels for opencv_contrib_python_headless
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_CONTRIB_PYTHON_HEADLESS_USERNAME }} -p ${{ secrets.OPENCV_CONTRIB_PYTHON_HEADLESS_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_contrib_python_headless-*
+        python -m pylint $PYLINT_TEST_FILE

--- a/.github/workflows/build_wheels_macos_m1.yml
+++ b/.github/workflows/build_wheels_macos_m1.yml
@@ -9,16 +9,21 @@ on:
       - '.github/workflows/build_wheels_manylinux*'
       - '.github/workflows/build_wheels_windows*'
       - '.github/workflows/build_wheels_macos.yml'
-  release:
-    types: [published, edited]
-  schedule:
-    - cron: '0 3 * * 6'
+      - '.github/workflows/build_sdist.yml'
+      - '.github/workflows/release.yml'
+  workflow_call:
+    inputs:
+      rolling:
+        type: boolean
+        default: false
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 jobs:
   Build:
-    runs-on: python-macos12-m1
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:
@@ -34,37 +39,38 @@ jobs:
       ENABLE_CONTRIB: ${{ matrix.with_contrib }}
       PIP_INDEX_URL: https://pypi.tuna.tsinghua.edu.cn/simple
     steps:
-    - name: Cleanup
-      run: find . -mindepth 1 -delete
-      working-directory: ${{ github.workspace }}
     - name: Setup environment
+      if: inputs.rolling == 'true' || github.event_name == 'workflow_dispatch'
       run: |
-        if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-          echo "ENABLE_ROLLING=1" >> $GITHUB_ENV
-        fi
+        echo "ENABLE_ROLLING=1" >> $GITHUB_ENV
     - name: Checkout
       uses: actions/checkout@v7
       with:
         submodules: false
         fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v7
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.platform }}
     - name: Build a package
       run: |
         git submodule update --init multibuild
         echo $ENABLE_CONTRIB > contrib.enabled
         echo $ENABLE_HEADLESS > headless.enabled
         export MACOSX_DEPLOYMENT_TARGET=13.0
-        python${{ matrix.python-version }} -m pip install toml && python${{ matrix.python-version }} -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | python${{ matrix.python-version }} -m pip install -r /dev/stdin
-        python${{ matrix.python-version }} setup.py bdist_wheel --py-limited-api=cp37 --dist-dir=wheelhouse -v
+        python -m pip install toml && python -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | python -m pip install -r /dev/stdin
+        python setup.py bdist_wheel --py-limited-api=cp37 --dist-dir=wheelhouse -v
         delocate-wheel ${{ github.workspace }}/wheelhouse/opencv*
     - name: Saving a wheel accordingly to matrix
       uses: actions/upload-artifact@v7
       with:
-        name: wheel-${{ matrix.with_contrib }}-${{ matrix.without_gui }}-${{ matrix.build_sdist }}
+        name: build-${{ matrix.platform }}-macos-${{ matrix.with_contrib }}-${{ matrix.without_gui }}-${{ matrix.build_sdist }}
         path: wheelhouse/opencv*.whl
 
   Test:
     needs: [Build]
-    runs-on: python-macos12-m1
+    runs-on: macos-26
     strategy:
       fail-fast: false
       matrix:
@@ -89,104 +95,32 @@ jobs:
     - name: Download a wheel accordingly to matrix
       uses: actions/download-artifact@v8
       with:
-        name: wheel-${{ matrix.with_contrib }}-${{ matrix.without_gui }}-${{ matrix.build_sdist }}
+        name: build-${{ matrix.platform }}-macos-${{ matrix.with_contrib }}-${{ matrix.without_gui }}-${{ matrix.build_sdist }}
         path: wheelhouse/
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v7
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.platform }}
     - name: Create Venv for test
       run: |
         test -d "${{ github.workspace }}/opencv_test" && rm -rf "${{ github.workspace }}/opencv_test"
-        python${{ matrix.python-version }} -m venv ${{ github.workspace }}/opencv_test
+        python -m venv ${{ github.workspace }}/opencv_test
     - name: Package installation
       run: |
         source ${{ github.workspace }}/opencv_test/bin/activate
-        python${{ matrix.python-version }} -m pip install --upgrade pip
-        python${{ matrix.python-version }} -m pip install --no-cache --force-reinstall wheelhouse/opencv*.whl
+        python -m pip install --upgrade pip
+        python -m pip install --no-cache --force-reinstall wheelhouse/opencv*.whl
         cd ${{ github.workspace }}/tests
-        python${{ matrix.python-version }} get_build_info.py
+        python get_build_info.py
     - name: Run tests
       run: |
         source ${{ github.workspace }}/opencv_test/bin/activate
         cd ${{ github.workspace }}/opencv
-        python${{ matrix.python-version }} modules/python/test/test.py -v --repo .
+        python modules/python/test/test.py -v --repo .
     - name: Pylint test
       run: |
         source ${{ github.workspace }}/opencv_test/bin/activate
-        python${{ matrix.python-version }} -m pip install pylint==2.15.9
+        python -m pip install pylint==2.15.9
         cd ${{ github.workspace }}/tests
-        python${{ matrix.python-version }} -m pylint $PYLINT_TEST_FILE
-
-  Release_rolling:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-    needs: [Build, Test]
-    runs-on: ubuntu-22.04
-    environment: opencv-python-rolling-release
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          name: wheels
-          path: wheelhouse/
-      - name: Upload wheels for opencv_python_rolling
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_PYTHON_ROLLING_USERNAME }} -p ${{ secrets.OPENCV_PYTHON_ROLLING_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_python_rolling-*
-      - name: Upload wheels for opencv_contrib_python_rolling
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_CONTRIB_PYTHON_ROLLING_USERNAME }} -p ${{ secrets.OPENCV_CONTRIB_PYTHON_ROLLING_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_contrib_python_rolling-*
-      - name: Upload wheels for opencv_python_headless_rolling
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_PYTHON_HEADLESS_ROLLING_USERNAME }} -p ${{ secrets.OPENCV_PYTHON_HEADLESS_ROLLING_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_python_headless_rolling-*
-      - name: Upload wheels for opencv_contrib_python_headless_rolling
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_CONTRIB_PYTHON_HEADLESS_ROLLING_USERNAME }} -p ${{ secrets.OPENCV_CONTRIB_PYTHON_HEADLESS_ROLLING_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_contrib_python_headless_rolling-*
-
-  Pre-release:
-    if: github.event_name == 'release' && github.event.release.prerelease
-    needs: [Build, Test]
-    runs-on: ubuntu-22.04
-    environment: test-opencv-python-release
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: wheelhouse/
-      - name: Upload all wheels
-        run: |
-          tree
-          python -m pip install twine
-          python -m twine upload --repository testpypi -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_*
-
-  Release:
-    if: github.event_name == 'release' && !github.event.release.prerelease
-    needs: [Build, Test]
-    runs-on: ubuntu-22.04
-    environment: opencv-python-release
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: wheelhouse/
-      - name: Upload wheels for opencv_python
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_PYTHON_USERNAME }} -p ${{ secrets.OPENCV_PYTHON_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_python-*
-      - name: Upload wheels for opencv_contrib_python
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_CONTRIB_PYTHON_USERNAME }} -p ${{ secrets.OPENCV_CONTRIB_PYTHON_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_contrib_python-*
-      - name: Upload wheels for opencv_python_headless
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_PYTHON_HEADLESS_USERNAME }} -p ${{ secrets.OPENCV_PYTHON_HEADLESS_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_python_headless-*
-      - name: Upload wheels for opencv_contrib_python_headless
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_CONTRIB_PYTHON_HEADLESS_USERNAME }} -p ${{ secrets.OPENCV_CONTRIB_PYTHON_HEADLESS_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_contrib_python_headless-*
+        python -m pylint $PYLINT_TEST_FILE

--- a/.github/workflows/build_wheels_manylinux.yml
+++ b/.github/workflows/build_wheels_manylinux.yml
@@ -8,16 +8,21 @@ on:
     paths-ignore:
       - '.github/workflows/build_wheels_windows*'
       - '.github/workflows/build_wheels_macos*'
-  release:
-    types: [published, edited]
-  schedule:
-    - cron: '0 3 * * 6'
+      - '.github/workflows/build_sdist.yml'
+      - '.github/workflows/release.yml'
+  workflow_call:
+    inputs:
+      rolling:
+        type: boolean
+        default: false
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 jobs:
   Build:
-    runs-on: ${{ matrix.platform == 'aarch64' && 'opencv-cn-lin-arm64' || 'ubuntu-22.04' }}
+    runs-on: ${{ case(matrix.platform == 'aarch64', 'ubuntu-24.04-arm', 'ubuntu-24.04') }}
     defaults:
       run:
         shell: bash
@@ -33,16 +38,16 @@ jobs:
         include:
           - platform: aarch64
             manylinux: 2014
-            DOCKER_IMAGE: quay.io/opencv-ci/opencv-python-manylinux2014-aarch64:20260725
+            DOCKER_IMAGE: quay.io/opencv-ci/opencv-python-manylinux2014-aarch64:20260725@sha256:bc553cbe81920f9157d0cf3abc282da7cb5502fa4dfc40018432adbb26844168
           - platform: x86_64
             manylinux: 2014
-            DOCKER_IMAGE: quay.io/opencv-ci/opencv-python-manylinux2014-x86-64:20260725
+            DOCKER_IMAGE: quay.io/opencv-ci/opencv-python-manylinux2014-x86-64:20260725@sha256:b31dbd9260993812b011eeea543fe3bad30cd1803dd54963ffd74bb4b7e31f38
           - platform: x86_64
             manylinux: 2_28
-            DOCKER_IMAGE: quay.io/opencv-ci/opencv-python-manylinux_2_28-x86-64:20260725
+            DOCKER_IMAGE: quay.io/opencv-ci/opencv-python-manylinux_2_28-x86-64:20260725@sha256:d818791d2190f3ab4dda1e4683feade139bb345b4511a8a5ed9caf9e5f660a29
           - platform: aarch64
             manylinux: 2_28
-            DOCKER_IMAGE: quay.io/opencv-ci/opencv-python-manylinux_2_28-aarch64:20260725
+            DOCKER_IMAGE: quay.io/opencv-ci/opencv-python-manylinux_2_28-aarch64:20260725@sha256:ba83daf0ce7653bc43df249d06fa05b0e03dfa4e94d7b3146e8be317091edea2
 
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
@@ -66,10 +71,9 @@ jobs:
       run: find . -mindepth 1 -delete
       working-directory: ${{ github.workspace }}
     - name: Setup environment
+      if: inputs.rolling == 'true' || github.event_name == 'workflow_dispatch'
       run: |
-        if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-          echo "ENABLE_ROLLING=1" >> $GITHUB_ENV
-        fi
+        echo "ENABLE_ROLLING=1" >> $GITHUB_ENV
     - name: Checkout
       uses: actions/checkout@v7
       with:
@@ -81,12 +85,12 @@ jobs:
     - name: Saving a wheel accordingly to matrix
       uses: actions/upload-artifact@v7
       with:
-        name: wheel-${{ matrix.platform }}-${{ matrix.manylinux }}-${{ matrix.with_contrib }}-${{ matrix.without_gui }}-${{ matrix.build_sdist }}
+        name: build-${{ matrix.platform }}-${{ matrix.manylinux }}-${{ matrix.with_contrib }}-${{ matrix.without_gui }}-${{ matrix.build_sdist }}
         path: wheelhouse/opencv*.whl
 
   Test:
     needs: [Build]
-    runs-on: ${{ matrix.platform == 'aarch64' && 'opencv-cn-lin-arm64' || 'ubuntu-22.04' }}
+    runs-on: ${{ case(matrix.platform == 'aarch64', 'ubuntu-24.04-arm', 'ubuntu-24.04') }}
     defaults:
       run:
         shell: bash
@@ -111,7 +115,7 @@ jobs:
       SDIST: ${{ matrix.build_sdist || 0 }}
       ENABLE_HEADLESS: ${{ matrix.without_gui }}
       ENABLE_CONTRIB: ${{ matrix.with_contrib }}
-      DOCKER_TEST_IMAGE: ${{ matrix.platform == 'aarch64' && 'quay.io/opencv-ci/multibuild-noble_arm64v8:2026-06-15' || '' }}
+      DOCKER_TEST_IMAGE: ${{ case(matrix.platform == 'aarch64', 'quay.io/opencv-ci/multibuild-noble_arm64v8:2026-06-15', '') }}
     steps:
     - name: Cleanup
       run: find . -mindepth 1 -delete
@@ -124,164 +128,23 @@ jobs:
 
     - name: Setup Environment variables
       run: |
-        if [ "3.8" == "${{ matrix.python-version }}" -o "3.9" == "${{ matrix.python-version }}" ]
-        then
+        case "$PYTHON_VERSION" in
+          3.8|3.9)
             echo "TEST_DEPENDS=$(echo $NP_TEST_DEP_OLD)" >> $GITHUB_ENV
-        elif [ "3.10" == "${{ matrix.python-version }}" -o "3.11" == "${{ matrix.python-version }}" -o "3.12" == "${{ matrix.python-version }}" -o "3.13" == "${{ matrix.python-version }}" ]
-        then
+            ;;
+          3.10|3.11|3.12|3.13)
             echo "TEST_DEPENDS=$(echo $NP_TEST_DEP)" >> $GITHUB_ENV
-        else
+            ;;
+          *)
             echo "TEST_DEPENDS=$(echo $NP_TEST_DEP_LATEST)" >> $GITHUB_ENV
-        fi
+            ;;
+        esac
+      env:
+        PYTHON_VERSION: ${{ matrix.python-version }}
     - name: Download a wheel accordingly to matrix
       uses: actions/download-artifact@v8
       with:
-        name: wheel-${{ matrix.platform }}-${{ matrix.manylinux }}-${{ matrix.with_contrib }}-${{ matrix.without_gui }}-${{ matrix.build_sdist }}
+        name: build-${{ matrix.platform }}-${{ matrix.manylinux }}-${{ matrix.with_contrib }}-${{ matrix.without_gui }}-${{ matrix.build_sdist }}
         path: wheelhouse/
     - name: Package installation and run tests
       run: source scripts/install.sh
-
-  Build_sdist:
-    runs-on: ubuntu-22.04
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.8]
-        platform: [x64]
-        with_contrib: [0, 1]
-        without_gui: [0, 1]
-        build_sdist: [1]
-    env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-      REPO_DIR: .
-      PROJECT_SPEC: opencv-python
-      PLAT: x86_64
-      MB_PYTHON_VERSION: ${{ matrix.python-version }}
-      TRAVIS_PYTHON_VERSION: ${{ matrix.python-version }}
-      MB_ML_VER: 2014
-      NP_TEST_DEP: numpy==1.19.4
-      TRAVIS_BUILD_DIR: ${{ github.workspace }}
-      CONFIG_PATH: travis_config.sh
-      DOCKER_IMAGE: quay.io/opencv-ci/opencv-python-manylinux2014-x86-64:20260102
-      USE_CCACHE: 1
-      UNICODE_WIDTH: 32
-      SDIST: ${{ matrix.build_sdist || 0 }}
-      ENABLE_HEADLESS: ${{ matrix.without_gui || 0 }}
-      ENABLE_CONTRIB: ${{ matrix.with_contrib || 0 }}
-    steps:
-    - name: Cleanup
-      run: find . -mindepth 1 -delete
-      working-directory: ${{ github.workspace }}
-    - name: Setup environment
-      run: |
-        if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-          echo "ENABLE_ROLLING=1" >> $GITHUB_ENV
-        fi
-    - name: Checkout
-      uses: actions/checkout@v7
-      with:
-        submodules: false
-        fetch-depth: 0
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: ${{ matrix.platform }}
-    - name: Build a package
-      run: |
-        set -e
-        # Build and package
-        set -x
-          python -m pip install --upgrade pip
-          python -m pip install scikit-build
-          python setup.py sdist --formats=gztar
-        set +x
-        # Install and run tests
-        set -x
-        echo "skipping tests because of sdist"
-    - name: saving artifacts
-      uses: actions/upload-artifact@v7
-      with:
-        name: wheel-${{ matrix.with_contrib }}-${{ matrix.without_gui }}-${{ matrix.build_sdist }}
-        path: dist/opencv*.tar.gz
-
-  Release_rolling:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-    needs: [Build, Test]
-    runs-on: ubuntu-22.04
-    environment: opencv-python-rolling-release
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: wheelhouse/
-
-      - name: Upload wheels for opencv_python_rolling
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_PYTHON_ROLLING_USERNAME }} -p ${{ secrets.OPENCV_PYTHON_ROLLING_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_python_rolling-*
-      - name: Upload wheels for opencv_contrib_python_rolling
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_CONTRIB_PYTHON_ROLLING_USERNAME }} -p ${{ secrets.OPENCV_CONTRIB_PYTHON_ROLLING_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_contrib_python_rolling-*
-      - name: Upload wheels for opencv_python_headless_rolling
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_PYTHON_HEADLESS_ROLLING_USERNAME }} -p ${{ secrets.OPENCV_PYTHON_HEADLESS_ROLLING_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_python_headless_rolling-*
-      - name: Upload wheels for opencv_contrib_python_headless_rolling
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_CONTRIB_PYTHON_HEADLESS_ROLLING_USERNAME }} -p ${{ secrets.OPENCV_CONTRIB_PYTHON_HEADLESS_ROLLING_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_contrib_python_headless_rolling-*
-
-  Pre-release:
-    if: github.event_name == 'release' && github.event.release.prerelease
-    needs: [Build, Build_sdist, Test]
-    runs-on: ubuntu-22.04
-    environment: test-opencv-python-release
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: wheelhouse/
-
-      - name: Upload all wheels
-        run: |
-          tree
-          python -m pip install twine
-          python -m twine upload --repository testpypi -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_* wheelhouse/wheel-*/opencv-*
-
-  Release:
-    if: github.event_name == 'release' && !github.event.release.prerelease
-    needs: [Build, Build_sdist, Test]
-    runs-on: ubuntu-22.04
-    environment: opencv-python-release
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: wheelhouse/
-      - name: Upload wheels for opencv_python
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_PYTHON_USERNAME }} -p ${{ secrets.OPENCV_PYTHON_PASSWORD }} --skip-existing wheelhouse/opencv_python-* wheelhouse/opencv-python-[^h]*
-      - name: Upload wheels for opencv_contrib_python
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_CONTRIB_PYTHON_USERNAME }} -p ${{ secrets.OPENCV_CONTRIB_PYTHON_PASSWORD }} --skip-existing wheelhouse/opencv_contrib_python-* wheelhouse/opencv-contrib-python-[^h]*
-      - name: Upload wheels for opencv_python_headless
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_PYTHON_HEADLESS_USERNAME }} -p ${{ secrets.OPENCV_PYTHON_HEADLESS_PASSWORD }} --skip-existing wheelhouse/opencv_python_headless-* wheelhouse/opencv-python-headless-*
-      - name: Upload wheels for opencv_contrib_python_headless
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_CONTRIB_PYTHON_HEADLESS_USERNAME }} -p ${{ secrets.OPENCV_CONTRIB_PYTHON_HEADLESS_PASSWORD }} --skip-existing wheelhouse/opencv_contrib_python_headless-* wheelhouse/opencv-contrib-python-headless-*

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -8,12 +8,17 @@ on:
     paths-ignore:
       - '.github/workflows/build_wheels_manylinux*'
       - '.github/workflows/build_wheels_macos*'
-  release:
-    types: [published, edited]
-  schedule:
-    - cron: '0 3 * * 6'
+      - '.github/workflows/build_sdist.yml'
+      - '.github/workflows/release.yml'
+  workflow_call:
+    inputs:
+      rolling:
+        type: boolean
+        default: false
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 jobs:
   Build:
@@ -41,17 +46,16 @@ jobs:
       working-directory: ${{ github.workspace }}
     - name: Setup environment
       shell: bash
+      if: inputs.rolling == 'true' || github.event_name == 'workflow_dispatch'
       run: |
-        if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-          echo "ENABLE_ROLLING=1" >> $GITHUB_ENV
-        fi
+        echo "ENABLE_ROLLING=1" >> $GITHUB_ENV
     - name: Checkout
       uses: actions/checkout@v7
       with:
         submodules: false
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.platform }}
@@ -72,7 +76,7 @@ jobs:
     - name: Saving all wheels
       uses: actions/upload-artifact@v7
       with:
-        name: wheel-${{ matrix.with_contrib }}-${{ matrix.without_gui }}-${{ matrix.build_sdist }}-${{ matrix.platform }}
+        name: build-${{ matrix.platform }}-windows-${{ matrix.with_contrib }}-${{ matrix.without_gui }}-${{ matrix.build_sdist }}
         path: wheelhouse/opencv*
 
   Test:
@@ -107,14 +111,14 @@ jobs:
         submodules: true
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.platform }}
     - name: Download a wheel accordingly to matrix
       uses: actions/download-artifact@v8
       with:
-        name: wheel-${{ matrix.with_contrib }}-${{ matrix.without_gui }}-${{ matrix.build_sdist }}-${{ matrix.platform }}
+        name: build-${{ matrix.platform }}-windows-${{ matrix.with_contrib }}-${{ matrix.without_gui }}-${{ matrix.build_sdist }}
         path: wheelhouse/
     - name: Package installation
       run: |
@@ -132,78 +136,3 @@ jobs:
         python -m pip install pylint==2.15.9
         cd ${{ github.workspace }}\tests
         python -m pylint $PYLINT_TEST_FILE
-
-  Release_rolling:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-    needs: [Build, Test]
-    runs-on: ubuntu-22.04
-    environment: opencv-python-rolling-release
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: wheelhouse/
-      - name: Upload wheels for opencv_python_rolling
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_PYTHON_ROLLING_USERNAME }} -p ${{ secrets.OPENCV_PYTHON_ROLLING_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_python_rolling-*
-      - name: Upload wheels for opencv_contrib_python_rolling
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_CONTRIB_PYTHON_ROLLING_USERNAME }} -p ${{ secrets.OPENCV_CONTRIB_PYTHON_ROLLING_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_contrib_python_rolling-*
-      - name: Upload wheels for opencv_python_headless_rolling
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_PYTHON_HEADLESS_ROLLING_USERNAME }} -p ${{ secrets.OPENCV_PYTHON_HEADLESS_ROLLING_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_python_headless_rolling-*
-      - name: Upload wheels for opencv_contrib_python_headless_rolling
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_CONTRIB_PYTHON_HEADLESS_ROLLING_USERNAME }} -p ${{ secrets.OPENCV_CONTRIB_PYTHON_HEADLESS_ROLLING_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_contrib_python_headless_rolling-*
-
-  Pre-release:
-    if: github.event_name == 'release' && github.event.release.prerelease
-    needs: [Build, Test]
-    runs-on: ubuntu-22.04
-    environment: test-opencv-python-release
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: wheelhouse/
-      - name: Upload all wheels
-        run: |
-          python -m pip install twine
-          python -m twine upload --repository testpypi -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_*
-
-  Release:
-    if: github.event_name == 'release' && !github.event.release.prerelease
-    needs: [Build, Test]
-    runs-on: ubuntu-22.04
-    environment: opencv-python-release
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: wheelhouse/
-      - name: Upload wheels for opencv_python
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_PYTHON_USERNAME }} -p ${{ secrets.OPENCV_PYTHON_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_python-*
-      - name: Upload wheels for opencv_contrib_python
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_CONTRIB_PYTHON_USERNAME }} -p ${{ secrets.OPENCV_CONTRIB_PYTHON_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_contrib_python-*
-      - name: Upload wheels for opencv_python_headless
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_PYTHON_HEADLESS_USERNAME }} -p ${{ secrets.OPENCV_PYTHON_HEADLESS_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_python_headless-*
-      - name: Upload wheels for opencv_contrib_python_headless
-        run: |
-          python -m pip install twine
-          python -m twine upload -u ${{ secrets.OPENCV_CONTRIB_PYTHON_HEADLESS_USERNAME }} -p ${{ secrets.OPENCV_CONTRIB_PYTHON_HEADLESS_PASSWORD }} --skip-existing wheelhouse/wheel-*/opencv_contrib_python_headless-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,193 @@
+name: Release
+
+on:
+  release:
+    types: [published, edited]
+  schedule:
+    - cron: '0 3 * * 6'
+  workflow_dispatch:
+
+jobs:
+  Build-macos-m1:
+    uses: $/.github/workflows/build_wheels_macos_m1.yml
+    with:
+      rolling: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+  Build-macos:
+    uses: $/.github/workflows/build_wheels_macos.yml
+    with:
+      rolling: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+  Build-windows:
+    uses: $/.github/workflows/build_wheels_windows.yml
+    with:
+      rolling: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+  Build-manylinux:
+    uses: $/.github/workflows/build_wheels_manylinux.yml
+    with:
+      rolling: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+  Build_sdist:
+    uses: $/.github/workflows/build_sdist.yml
+    with:
+      rolling: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+
+  Release_opencv_python_rolling:
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    needs: [Build-macos-m1, Build-macos, Build-windows, Build-manylinux, Build_sdist]
+    runs-on: ubuntu-latest
+    environment: opencv-python-rolling
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: build-*-*-0-0-0
+          path: dist/
+
+      - name: Upload wheels for opencv_python_rolling
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        with:
+          skip-existing: true
+          packages-dir: dist/build-*/opencv_python_rolling-*
+
+  Release_opencv_contrib_python_rolling:
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    needs: [Build-macos-m1, Build-macos, Build-windows, Build-manylinux, Build_sdist]
+    runs-on: ubuntu-latest
+    environment: opencv-contrib-python-rolling
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: build-*-*-1-0-0
+          path: dist/
+      - name: Upload wheels for opencv_contrib_python_rolling
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        with:
+          skip-existing: true
+          packages-dir: dist/build-*/opencv_contrib_python_rolling-*
+
+  Release_opencv_python_headless_rolling:
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    needs: [Build-macos-m1, Build-macos, Build-windows, Build-manylinux, Build_sdist]
+    runs-on: ubuntu-latest
+    environment: opencv-python-headless-rolling
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: build-*-*-0-1-0
+          path: dist/
+      - name: Upload wheels for opencv_python_headless_rolling
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        with:
+          skip-existing: true
+          packages-dir: dist/build-*/opencv_python_headless_rolling-*
+
+  Release_opencv_contrib_python_headless_rolling:
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    needs: [Build-macos-m1, Build-macos, Build-windows, Build-manylinux, Build_sdist]
+    runs-on: ubuntu-latest
+    environment: opencv-contrib-python-headless-rolling
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: build-*-*-1-1-0
+          path: dist/
+      - name: Upload wheels for opencv_contrib_python_headless_rolling
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        with:
+          skip-existing: true
+          packages-dir: dist/build-*/opencv_contrib_python_headless_rolling-*
+
+  Pre-release:
+    if: github.event_name == 'release' && github.event.release.prerelease
+    needs: [Build-macos-m1, Build-macos, Build-windows, Build-manylinux, Build_sdist]
+    runs-on: ubuntu-latest
+    environment: test-opencv-python-release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: dist/
+      - name: Upload all wheels
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        with:
+          skip-existing: true
+          packages-dir: dist/build-*/opencv_*
+          repository-url: https://test.pypi.org/legacy/
+
+  Release_opencv_python:
+    if: github.event_name == 'release' && !github.event.release.prerelease
+    needs: [Build-macos-m1, Build-macos, Build-windows, Build-manylinux, Build_sdist]
+    runs-on: ubuntu-latest
+    environment: opencv-python
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: build-*-*-0-0-0
+          path: dist/
+      - name: Upload wheels for opencv_python
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        with:
+          skip-existing: true
+          packages-dir: dist/build-*/opencv-python-[^h]*
+
+  Release_opencv_contrib_python:
+    if: github.event_name == 'release' && !github.event.release.prerelease
+    needs: [Build-macos-m1, Build-macos, Build-windows, Build-manylinux, Build_sdist]
+    runs-on: ubuntu-latest
+    environment: opencv-contrib-python
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: build-*-*-0-1-0
+          path: dist/
+      - name: Upload wheels for opencv_contrib_python
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        with:
+          skip-existing: true
+          packages-dir: dist/build-*/opencv-contrib-python-[^h]*
+
+  Release_opencv_python_headless:
+    if: github.event_name == 'release' && !github.event.release.prerelease
+    needs: [Build-macos-m1, Build-macos, Build-windows, Build-manylinux, Build_sdist]
+    runs-on: ubuntu-latest
+    environment: opencv-python-headless
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: build-*-*-0-1-0
+          path: dist/
+      - name: Upload wheels for opencv_python_headless
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        with:
+          skip-existing: true
+          packages-dir: dist/build-*/opencv-python-headless-*
+
+  Release_opencv_contrib_python_headless:
+    if: github.event_name == 'release' && !github.event.release.prerelease
+    needs: [Build-macos-m1, Build-macos, Build-windows, Build-manylinux, Build_sdist]
+    runs-on: ubuntu-latest
+    environment: opencv-contrib-python-headless
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: build-*-*-0-1-0
+          path: dist/
+      - name: Upload wheels for opencv_contrib_python_headless
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        with:
+          skip-existing: true
+          packages-dir: dist/build-*/opencv-contrib-python-headless-*


### PR DESCRIPTION
PyPi releases were not those built in this repository. For better supply chain traceability, use trusted publishing that creates the attestations required.

This also moves to use GitHub hosted runners for ubuntu ARM64 and MacOS intel and M1 builds.

Fixes #1191.

This requires setup of

- an environment for each project on PyPi on GitHub and
- a Trusted Publisher configuration for each project on PyPi to accept the `release.yml` workflow with the environment to publish on the project